### PR TITLE
Fix Contrast Issue in Catppuccin Mocha Theme

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "postcss-scss": "^4.0.9",
     "sass": "^1.85.1",
     "sass-loader": "^16.0.5",
-    "stylelint": "^16.15.0",
+    "stylelint": "^16.16.0",
     "stylelint-config-sass-guidelines": "^12.1.0",
     "stylelint-config-standard": "^37.0.0",
     "stylelint-high-performance-animation": "^1.11.0",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "copy-webpack-plugin": "^13.0.0",
     "css-loader": "^7.1.2",
     "css-minimizer-webpack-plugin": "^7.0.2",
-    "electron": "^35.0.1",
+    "electron": "^35.0.2",
     "electron-builder": "^25.1.8",
     "eslint": "^9.22.0",
     "eslint-plugin-jsdoc": "^50.6.6",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "youtubei.js": "^13.1.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.26.9",
+    "@babel/core": "^7.26.10",
     "@babel/plugin-transform-class-properties": "^7.25.9",
     "@babel/preset-env": "^7.26.9",
     "@double-great/stylelint-a11y": "^3.0.4",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "electron": "^35.0.1",
     "electron-builder": "^25.1.8",
     "eslint": "^9.22.0",
-    "eslint-plugin-jsdoc": "^50.6.3",
+    "eslint-plugin-jsdoc": "^50.6.6",
     "eslint-plugin-jsonc": "^2.19.1",
     "eslint-plugin-unicorn": "^57.0.0",
     "eslint-plugin-vue": "^10.0.0",

--- a/src/botGuardScript.js
+++ b/src/botGuardScript.js
@@ -1,37 +1,90 @@
-import { BG } from 'bgutils-js'
+import { BG, buildURL, GOOG_API_KEY } from 'bgutils-js'
 
 // This script has it's own webpack config, as it gets passed as a string to Electron's evaluateJavaScript function
 // in src/main/poTokenGenerator.js
-export default async function(visitorData) {
+
+/**
+ * Based on: https://github.com/LuanRT/BgUtils/blob/main/examples/node/innertube-challenge-fetcher-example.ts
+ * @param {string} videoId
+ * @param {string} visitorData
+ * @param {import('youtubei.js').Session['context']} context
+ */
+export default async function (videoId, visitorData, context) {
   const requestKey = 'O43z0dpjhgX20SCx4KAo'
 
-  const bgConfig = {
-    fetch: (input, init) => fetch(input, init),
-    requestKey,
-    globalObj: window,
-    identifier: visitorData
+  const challengeResponse = await fetch(
+    'https://www.youtube.com/youtubei/v1/att/get?prettyPrint=false&alt=json',
+    {
+      method: 'POST',
+      headers: {
+        Accept: '*/*',
+        'Content-Type': 'application/json',
+        'X-Goog-Visitor-Id': visitorData,
+        'X-Youtube-Client-Version': context.client.clientVersion,
+        'X-Youtube-Client-Name': '1'
+      },
+      body: JSON.stringify({
+        engagementType: 'ENGAGEMENT_TYPE_UNBOUND',
+        context
+      }),
+    }
+  )
+
+  if (!challengeResponse.ok) {
+    throw new Error(`Request to ${challengeResponse.url} failed with status ${challengeResponse.status}\n${await challengeResponse.text()}`)
   }
 
-  const challenge = await BG.Challenge.create(bgConfig)
+  const challengeData = await challengeResponse.json()
 
-  if (!challenge) {
-    throw new Error('Could not get challenge')
+  if (!challengeData.bgChallenge) {
+    throw new Error('Failed to get BotGuard challenge')
   }
 
-  const interpreterJavascript = challenge.interpreterJavascript.privateDoNotAccessOrElseSafeScriptWrappedValue
+  let interpreterUrl = challengeData.bgChallenge.interpreterUrl.privateDoNotAccessOrElseTrustedResourceUrlWrappedValue
+
+  if (interpreterUrl.startsWith('//')) {
+    interpreterUrl = `https:${interpreterUrl}`
+  }
+
+  const bgScriptResponse = await fetch(interpreterUrl)
+  const interpreterJavascript = await bgScriptResponse.text()
 
   if (interpreterJavascript) {
     // eslint-disable-next-line no-new-func
     new Function(interpreterJavascript)()
   } else {
-    console.warn('Unable to load VM.')
+    throw new Error('Could not load VM.')
   }
 
-  const poTokenResult = await BG.PoToken.generate({
-    program: challenge.program,
-    globalName: challenge.globalName,
-    bgConfig
+  const botGuard = await BG.BotGuardClient.create({
+    program: challengeData.bgChallenge.program,
+    globalName: challengeData.bgChallenge.globalName,
+    globalObj: window
   })
 
-  return poTokenResult.poToken
+  const webPoSignalOutput = []
+  const botGuardResponse = await botGuard.snapshot({ webPoSignalOutput })
+
+  const integrityTokenResponse = await fetch(buildURL('GenerateIT', true), {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json+protobuf',
+      'x-goog-api-key': GOOG_API_KEY,
+      'x-user-agent': 'grpc-web-javascript/0.1',
+    },
+    body: JSON.stringify([requestKey, botGuardResponse])
+  })
+
+  const response = await integrityTokenResponse.json()
+
+  if (typeof response[0] !== 'string') {
+    throw new Error('Could not get integrity token')
+  }
+
+  const integrityTokenBasedMinter = await BG.WebPoMinter.create({ integrityToken: response[0] }, webPoSignalOutput)
+
+  const contentPoToken = await integrityTokenBasedMinter.mintAsWebsafeString(videoId)
+  const sessionPoToken = await integrityTokenBasedMinter.mintAsWebsafeString(visitorData)
+
+  return { contentPoToken, sessionPoToken }
 }

--- a/src/constants.js
+++ b/src/constants.js
@@ -45,7 +45,7 @@ const IpcChannels = {
 
   SET_INVIDIOUS_AUTHORIZATION: 'set-invidious-authorization',
 
-  GENERATE_PO_TOKEN: 'generate-po-token',
+  GENERATE_PO_TOKENS: 'generate-po-tokens',
 
   GET_SCREENSHOT_FALLBACK_FOLDER: 'get-screenshot-fallback-folder',
   CHOOSE_DEFAULT_FOLDER: 'choose-default-folder',

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -901,8 +901,8 @@ function runApp() {
     })
   })
 
-  ipcMain.handle(IpcChannels.GENERATE_PO_TOKEN, (_, visitorData) => {
-    return generatePoToken(visitorData, proxyUrl)
+  ipcMain.handle(IpcChannels.GENERATE_PO_TOKENS, (_, videoId, visitorData, context) => {
+    return generatePoToken(videoId, visitorData, context, proxyUrl)
   })
 
   ipcMain.on(IpcChannels.ENABLE_PROXY, (_, url) => {

--- a/src/main/poTokenGenerator.js
+++ b/src/main/poTokenGenerator.js
@@ -9,11 +9,13 @@ import { join } from 'path'
  * This is intentionally split out into it's own thing, with it's own temporary in-memory session,
  * as the BotGuard stuff accesses the global `document` and `window` objects and also requires making some requests.
  * So we definitely don't want it running in the same places as the rest of the FreeTube code with the user data.
+ * @param {string} videoId
  * @param {string} visitorData
+ * @param {string} context
  * @param {string|undefined} proxyUrl
- * @returns {Promise<string>}
+ * @returns {Promise<{ contentPoToken: string, sessionPoToken: string }>}
  */
-export async function generatePoToken(visitorData, proxyUrl) {
+export async function generatePoToken(videoId, visitorData, context, proxyUrl) {
   const sessionUuid = crypto.randomUUID()
 
   const theSession = session.fromPartition(`potoken-${sessionUuid}`, { cache: false })
@@ -22,18 +24,34 @@ export async function generatePoToken(visitorData, proxyUrl) {
   // eslint-disable-next-line n/no-callback-literal
   theSession.setPermissionRequestHandler((webContents, permission, callback) => callback(false))
 
-  theSession.setUserAgent(
-    theSession.getUserAgent()
-      .split(' ')
-      .filter(part => !part.includes('Electron'))
-      .join(' ')
-  )
+  theSession.setUserAgent(session.defaultSession.getUserAgent())
 
   if (proxyUrl) {
     await theSession.setProxy({
       proxyRules: proxyUrl
     })
   }
+
+  theSession.webRequest.onBeforeSendHeaders({
+    urls: ['https://www.google.com/js/*', 'https://www.youtube.com/youtubei/*']
+  }, ({ requestHeaders, url }, callback) => {
+    if (url.startsWith('https://www.youtube.com/youtubei/')) {
+      // make InnerTube requests work with the fetch function
+      // InnerTube rejects requests if the referer isn't YouTube or empty
+      requestHeaders.Referer = 'https://www.youtube.com/'
+      requestHeaders.Origin = 'https://www.youtube.com'
+
+      requestHeaders['Sec-Fetch-Site'] = 'same-origin'
+      requestHeaders['Sec-Fetch-Mode'] = 'same-origin'
+      requestHeaders['X-Youtube-Bootstrap-Logged-In'] = 'false'
+    } else {
+      requestHeaders['Sec-Fetch-Dest'] = 'script'
+      requestHeaders['Sec-Fetch-Site'] = 'cross-site'
+      requestHeaders['Accept-Language'] = '*'
+    }
+
+    callback({ requestHeaders })
+  })
 
   const webContentsView = new WebContentsView({
     webPreferences: {
@@ -42,7 +60,8 @@ export async function generatePoToken(visitorData, proxyUrl) {
       sandbox: true,
       v8CacheOptions: 'none',
       session: theSession,
-      offscreen: true
+      offscreen: true,
+      webSecurity: false
     }
   })
 
@@ -58,43 +77,8 @@ export async function generatePoToken(visitorData, proxyUrl) {
 
   webContentsView.webContents.debugger.attach()
 
-  await webContentsView.webContents.loadURL('data:text/html,', {
-    baseURLForDataURL: 'https://www.youtube.com'
-  })
-
-  await webContentsView.webContents.debugger.sendCommand('Emulation.setUserAgentOverride', {
-    userAgent: theSession.getUserAgent(),
-    acceptLanguage: 'en-US',
-    platform: 'Win32',
-    userAgentMetadata: {
-      brands: [
-        {
-          brand: 'Not/A)Brand',
-          version: '99'
-        },
-        {
-          brand: 'Chromium',
-          version: process.versions.chrome.split('.')[0]
-        }
-      ],
-      fullVersionList: [
-        {
-          brand: 'Not/A)Brand',
-          version: '99.0.0.0'
-        },
-        {
-          brand: 'Chromium',
-          version: process.versions.chrome
-        }
-      ],
-      platform: 'Windows',
-      platformVersion: '10.0.0',
-      architecture: 'x86',
-      model: '',
-      mobile: false,
-      bitness: '64',
-      wow64: false
-    }
+  await webContentsView.webContents.loadURL('data:text/html,<!DOCTYPE html><html lang="en"><head><title></title></head><body></body></html>', {
+    baseURLForDataURL: 'https://www.youtube.com/'
   })
 
   await webContentsView.webContents.debugger.sendCommand('Emulation.setDeviceMetricsOverride', {
@@ -112,7 +96,7 @@ export async function generatePoToken(visitorData, proxyUrl) {
     }
   })
 
-  const script = await getScript(visitorData)
+  const script = await getScript(videoId, visitorData, context)
 
   const response = await webContentsView.webContents.executeJavaScript(script)
 
@@ -125,9 +109,11 @@ export async function generatePoToken(visitorData, proxyUrl) {
 let cachedScript
 
 /**
+ * @param {string} videoId
  * @param {string} visitorData
+ * @param {string} context
  */
-async function getScript(visitorData) {
+async function getScript(videoId, visitorData, context) {
   if (!cachedScript) {
     const pathToScript = process.env.NODE_ENV === 'development'
       ? join(__dirname, '../../dist/botGuardScript.js')
@@ -140,8 +126,8 @@ async function getScript(visitorData) {
 
     const functionName = match[1]
 
-    cachedScript = content.replace(match[0], `;${functionName}("FT_VISITOR_DATA")`)
+    cachedScript = content.replace(match[0], `;${functionName}(FT_PARAMS)`)
   }
 
-  return cachedScript.replace('FT_VISITOR_DATA', visitorData)
+  return cachedScript.replace('FT_PARAMS', `"${videoId}","${visitorData}",${context}`)
 }

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -198,16 +198,24 @@ export async function getLocalSearchContinuation(continuationData) {
 export async function getLocalVideoInfo(id) {
   const webInnertube = await createInnertube({ withPlayer: true, generateSessionLocally: false })
 
-  let poToken
+  // based on the videoId (added to the body of the /player request)
+  let contentPoToken
+  // based on the visitor data (added to the streaming URLs)
+  let sessionPoToken
 
   if (process.env.IS_ELECTRON) {
     const { ipcRenderer } = require('electron')
 
     try {
-      poToken = await ipcRenderer.invoke(IpcChannels.GENERATE_PO_TOKEN, webInnertube.session.context.client.visitorData)
+      ({ contentPoToken, sessionPoToken } = await ipcRenderer.invoke(
+        IpcChannels.GENERATE_PO_TOKENS,
+        id,
+        webInnertube.session.context.client.visitorData,
+        JSON.stringify(webInnertube.session.context)
+      ))
 
-      webInnertube.session.po_token = poToken
-      webInnertube.session.player.po_token = poToken
+      webInnertube.session.po_token = contentPoToken
+      webInnertube.session.player.po_token = sessionPoToken
     } catch (error) {
       console.error('Local API, poToken generation failed', error)
       throw error
@@ -227,8 +235,8 @@ export async function getLocalVideoInfo(id) {
     const webEmbeddedInnertube = await createInnertube({ clientType: ClientType.WEB_EMBEDDED })
     webEmbeddedInnertube.session.context.client.visitorData = webInnertube.session.context.client.visitorData
 
-    if (poToken) {
-      webEmbeddedInnertube.session.po_token = poToken
+    if (contentPoToken) {
+      webEmbeddedInnertube.session.po_token = contentPoToken
     }
 
     const videoId = hasTrailer && trailerIsAgeRestricted ? info.playability_status.error_screen.video_id : id
@@ -283,9 +291,9 @@ export async function getLocalVideoInfo(id) {
       let url = info.streaming_data.dash_manifest_url
 
       if (url.includes('?')) {
-        url += `&pot=${encodeURIComponent(poToken)}&mpd_version=7`
+        url += `&pot=${encodeURIComponent(sessionPoToken)}&mpd_version=7`
       } else {
-        url += `${url.endsWith('/') ? '' : '/'}pot/${encodeURIComponent(poToken)}/mpd_version/7`
+        url += `${url.endsWith('/') ? '' : '/'}pot/${encodeURIComponent(sessionPoToken)}/mpd_version/7`
       }
 
       info.streaming_data.dash_manifest_url = url

--- a/static/locales/bg.yaml
+++ b/static/locales/bg.yaml
@@ -326,6 +326,12 @@ Settings:
       Gruvbox Dark: Gruvbox тъмна
       Gruvbox Light: Gruvbox светла
       Catppuccin Frappe: Catppuccin Frappe
+      Everforest Light Low: Everforest светло ниско
+      Everforest Light Hard: Everforest светло твърдо
+      Everforest Dark Hard: Everforest Тъмно твърдо
+      Everforest Light Medium: Everforest светло средно
+      Everforest Dark Medium: Everforest Тъмно средно
+      Everforest Dark Low: Everforest Тъмно ниско
     Main Color Theme:
       Main Color Theme: 'Основна цветова тема'
       Red: 'Червено'
@@ -373,14 +379,14 @@ Settings:
       Solarized Blue: Solarized Синьо
       Solarized Cyan: Solarized Синьозелено
       Solarized Green: Solarized Зелено
-      Gruvbox Dark Yellow: Gruvbox тъмножълто
+      Gruvbox Dark Yellow: Gruvbox Тъмножълто
       Gruvbox Dark Blue: Gruvbox Тъмносиньо
-      Gruvbox Dark Purple: Gruvbox Тъмнолилаво
+      Gruvbox Dark Purple: Gruvbox Тъмнопурпурно
       Gruvbox Dark Aqua: Gruvbox Тъмна вода
       Gruvbox Light Blue: Gruvbox Светлосиньо
-      Gruvbox Light Purple: Gruvbox Светлолилаво
+      Gruvbox Light Purple: Gruvbox Светлопурпурно
       Gruvbox Light Orange: Gruvbox Светлооранжево
-      Gruvbox Dark Green: Gruvbox тъмнозелено
+      Gruvbox Dark Green: Gruvbox Тъмнозелено
       Gruvbox Dark Orange: Gruvbox Тъмнооранжево
       Gruvbox Light Red: Gruvbox Светлочервено
       Catppuccin Frappe Pink: Catppuccin Frappe Розово
@@ -397,6 +403,20 @@ Settings:
       Catppuccin Frappe Sky: Catppuccin Frappe Небесносиньо
       Catppuccin Frappe Teal: Catppuccin Frappe Синьозелено
       Catppuccin Frappe Sapphire: Catppuccin Frappe Сапфир
+      Everforest Dark Red: Everforest Тъмночервено
+      Everforest Light Red: Everforest Светлочервено
+      Everforest Dark Blue: Everforest Тъмносиньо
+      Everforest Light Yellow: Everforest Светложълто
+      Everforest Light Green: Everforest Светлозелено
+      Everforest Dark Orange: Everforest Тъмнооранжево
+      Everforest Dark Yellow: Everforest Тъмножълто
+      Everforest Dark Green: Everforest Тъмнозелено
+      Everforest Dark Aqua: Everforest Тъмна вода
+      Everforest Light Orange: Everforest Светлооранжево
+      Everforest Dark Purple: Everforest Тъмнопурпурно
+      Everforest Light Aqua: Everforest Светла вода
+      Everforest Light Blue: Everforest Светлосиньо
+      Everforest Light Purple: Everforest Светлопурпурно
     Secondary Color Theme: 'Вторична цветова тема'
         #* Main Color Theme
     UI Scale: Мащаб на интерфейса
@@ -574,20 +594,20 @@ Settings:
     Display Titles Without Excessive Capitalisation: Показване на заглавията без излишни
       главни букви и препинателни знаци
     Hide Featured Channels: Скриване на препоръчаните канали
-    Hide Channel Playlists: Скриване на раздел "Плейлисти" на канала
-    Hide Channel Community: Скриване на раздел "Общност" на канала
-    Hide Channel Shorts: Скриване на раздел "Кратки видеа" на канала
+    Hide Channel Playlists: Скриване на раздел "Плейлисти"
+    Hide Channel Community: Скриване на раздел "Общност"
+    Hide Channel Shorts: Скриване на раздел "Кратки видеа"
     Sections:
       Channel Page: Страница на канала
       Side Bar: Странична лента
       Watch Page: Страница за гледане
       General: Общи
       Subscriptions Page: Страница с абонаменти
-    Hide Channel Releases: Скриване на раздел "Издания" на канала
+    Hide Channel Releases: Скриване на раздел "Издания"
     Hide Subscriptions Videos: Скриване на видеата в абонаментите
     Hide Subscriptions Shorts: Скриване на кратките видеа в абонаментите
     Hide Subscriptions Live: Скриване на абонаментите на живо
-    Hide Channel Podcasts: Скриване на раздел "Подкасти" на канала
+    Hide Channel Podcasts: Скриване на раздел "Подкасти"
     Hide Profile Pictures in Comments: Скриване на профилните снимки в коментарите
     Hide Subscriptions Community: Скриване на абонаментите Общност
     Hide Channels Disabled Message: Някои канали бяха блокирани с чрез идентификатор
@@ -600,8 +620,9 @@ Settings:
       текст
     Hide Videos and Playlists Containing Text Placeholder: Дума, част от дума или
       фраза
-    Hide Channel Home: Скриване на раздел "Начало" на канала
+    Hide Channel Home: Скриване на раздел "Начало"
     Show Added Items: Показване на добавените елементи
+    Hide Channel Courses: Скриване на раздел "Курсове"
   The app needs to restart for changes to take effect. Restart and apply change?: Приложението
     трябва да се рестартира за да се приложат промените. Рестартиране?
   Proxy Settings:
@@ -832,6 +853,10 @@ Channel:
   Home:
     Home: Начало
     View Playlist: Преглед на плейлиста
+  Courses:
+    Courses: Курсове
+    This channel does not currently have any courses: В момента този канал няма никакви
+      курсове
 Video:
   Mark As Watched: 'Отбелязване като гледано'
   Remove From History: 'Премахване от историята'

--- a/static/locales/da.yaml
+++ b/static/locales/da.yaml
@@ -40,9 +40,11 @@ Global:
     Video Count: 1 video | {count} videoer
     Channel Count: 1 kanal | {count} kanaler
     Comment Count: 1 kommentar | {count} kommentarer
+    Like Count: 1 like | {count} likes
   Community: Fællesskab
   Live: Live
   Sort By: Sortér efter
+  Shorts: Shorts
 Version {versionNumber} is now available!  Click for more details: 'Version {versionNumber}
   er nu tilgængelig!  Klik for flere detaljer'
 Download From Site: 'Hent Fra Netsted'
@@ -95,6 +97,10 @@ Search Filters:
     Live: Live
     HDR: HDR
     Features: Funktioner
+    Location: Placering
+    360 Video: 360 Video
+    VR180: VR180
+    Creative Commons: Creative Commons
 Subscriptions:
     # On Subscriptions Page
   Subscriptions: 'Abonnenter'
@@ -111,6 +117,9 @@ Subscriptions:
     Opdatér abonnenter for at se dem her.
   Empty Posts: Dine abonnerede kanaler har i øjeblikket ingen opslag.
   Load More Posts: Indlæs Flere Opslag
+  Subscriptions Tabs: Abonnement-faner
+  All Subscription Tabs Hidden: Alle abonnement-faner er skjult. Gør nogle faner synlige
+    i "{subsection}" under "{settingsSection}" for at se indhold her.
 Trending:
   Trending: 'Trender'
   Music: Musik
@@ -123,8 +132,7 @@ Playlists: 'Playlister'
 User Playlists:
   Your Playlists: 'Dine Playlister'
   Search bar placeholder: Søg efter Playlister
-  Empty Search Message: Der er ingen videoer i denne playliste, der passer til din
-    søgning
+  Empty Search Message: Ingen videoer i denne playliste matcher din søgning
   This playlist currently has no videos.: Denne playliste har i øjeblikket ingen videoer.
   Create New Playlist: Opret Ny Playliste
   Add to Playlist: Føj til Playliste
@@ -142,6 +150,8 @@ User Playlists:
     LatestCreatedFirst: Oprettet For Nyligt
     LatestUpdatedFirst: Opdateret For Nyligt
     EarliestPlayedFirst: Tidligst Afspillet
+    NameDescending: Å-A
+    NameAscending: A-Å
   Are you sure you want to delete this playlist? This cannot be undone: Er du sikker
     på, at du vil slette denne playliste? Dette kan ikke fortrydes.
   SinglePlaylistView:
@@ -167,6 +177,10 @@ User Playlists:
       There were no videos to remove.: Der var ingen videoer at fjerne.
       Playlist {playlistName} has been deleted.: Playliste {playlistName} er blevet
         slettet.
+      This playlist has a video with a duration error: Denne playliste indeholder
+        mindst én video uden varighed. Den sorteres, som om dens varighed er nul.
+      Video has been removed. Click here to undo.: Videoen blev fjernet. Klik her
+        for at fortryde.
   AddVideoPrompt:
     Select a playlist to add your N videos to: Vælg en playliste, du vil føje din
       video til | Vælg en playliste, du vil føje dine {videoCount} videoer til
@@ -185,6 +199,7 @@ User Playlists:
       Videoer Bliver Tilføjet'
     "{videoCount}/{totalVideoCount} Videos Already Added": '{videoCount}/{totalVideoCount}
       Videoer Allerede Tilføjet'
+    Allow Adding Duplicate Video(s): Tillad tilføjelse af duplikatvideo(er)
   CreatePlaylistPrompt:
     Toast:
       There was an issue with creating the playlist.: Der opstod et problem med at
@@ -203,6 +218,18 @@ User Playlists:
   Add to Favorites: Føj til {playlistName}
   Remove from Playlist: Fjern fra Playliste
   Playlist Name: Playliste Navn
+  The playlist has been successfully exported: Playlisten blev eksporteret
+  Export Playlist: Eksportér denne playliste
+  Playlists with Matching Videos: Playlister med matchende videoer
+  Are you sure you want to remove {playlistItemCount} duplicate videos from this playlist? This cannot be undone: Er
+    du sikker på, at du vil fjerne 1 duplikatvideo fra denne playliste? Det kan ikke
+    fortrydes. | Er du sikker på, at du vil fjerne {playlistItemCount} duplikatvideoer
+    fra denne playliste? Det kan ikke fortrydes.
+  Remove Duplicate Videos: Fjern duplikatvideoer
+  Are you sure you want to remove {playlistItemCount} watched videos from this playlist? This cannot be undone: Er
+    du sikker på, at du vil fjerne 1 set video fra denne playliste? Det kan ikke fortrydes.
+    | Er du sikker på, at du vil fjerne {playlistItemCount} sete videoer fra denne
+    playliste? Det kan ikke fortrydes.
 History:
   # On History Page
   History: 'Historik'
@@ -214,7 +241,7 @@ Settings:
   # On Settings Page
   Settings: 'Indstillinger'
   General Settings:
-    General Settings: 'Generelle Indstillinger'
+    General Settings: 'Generel'
     Check for Updates: 'Søg efter Opdateringer'
     Check for Latest Blog Posts: 'Søg efter Seneste Blogindlæg'
     Fallback to Non-Preferred Backend on Failure: 'Tilbagefald til Ikke-Foretrukken
@@ -258,8 +285,9 @@ Settings:
     Auto Load Next Page:
       Label: Auto-indlæs Næste Side
       Tooltip: Indlæs flere sider og kommentarer automatisk.
+    Open Deep Links In New Window: Åbn URL'er sendt til FreeTube i et nyt vindue
   Theme Settings:
-    Theme Settings: 'Temaindstillinger'
+    Theme Settings: 'Tema'
     Match Top Bar with Main Color: 'Tilpas Topbjælke til Primær Farve'
     Base Theme:
       Base Theme: 'Grundtema'
@@ -271,6 +299,12 @@ Settings:
       Catppuccin Mocha: Catppuccin Mokka
       Pastel Pink: Pastel Lyserød
       Nordic: Nordisk
+      Gruvbox Dark: Gruvbox Mørk
+      Gruvbox Light: Gruvbox Lys
+      Catppuccin Frappe: Catppuccin Frappe
+      Hot Pink: Hot Pink
+      Solarized Dark: Solarized Mørk
+      Solarized Light: Solarized Lys
     Main Color Theme:
       Main Color Theme: 'Primær Farvetema'
       Red: 'Rød'
@@ -310,6 +344,52 @@ Settings:
       Catppuccin Mocha Sapphire: Catppuccin Mokka Safir
       Catppuccin Mocha Blue: Catppuccin Mokka Blå
       Catppuccin Mocha Lavender: Catppuccin Mokka Lavendel
+      Catppuccin Frappe Maroon: Catppuccin Frappe Rødbrun
+      Catppuccin Frappe Sky: Catppuccin Frappe Himmel
+      Catppuccin Frappe Sapphire: Catppuccin Frappe Safir
+      Catppuccin Frappe Blue: Catppuccin Frappe Blå
+      Catppuccin Frappe Lavender: Catppuccin Frappe Lavendel
+      Gruvbox Dark Green: Gruvbox Mørk Grøn
+      Gruvbox Dark Yellow: Gruvbox Mørk Gul
+      Gruvbox Light Red: Gruvbox Lys Rød
+      Solarized Green: Solarized Grøn
+      Solarized Magenta: Solarized Magenta
+      Catppuccin Frappe Mauve: Catppuccin Frappe Lilla
+      Catppuccin Frappe Red: Catppuccin Frappe Rød
+      Catppuccin Frappe Peach: Catppuccin Frappe Fersken
+      Catppuccin Frappe Yellow: Catppuccin Frappe Gul
+      Catppuccin Frappe Teal: Catppuccin Frappe Blågrøn
+      Gruvbox Dark Blue: Gruvbox Mørk Blå
+      Gruvbox Dark Purple: Gruvbox Mørk Lilla
+      Gruvbox Light Blue: Gruvbox Lys Blå
+      Solarized Red: Solarized Rød
+      Solarized Violet: Solarized Violet
+      Solarized Blue: Solarized Blå
+      Everforest Dark Orange: Everforest Mørk Orange
+      Everforest Dark Aqua: Everforest Mørk Aqua
+      Everforest Dark Blue: Everforest Mørk Blå
+      Everforest Dark Purple: Everforest Mørk Lilla
+      Catppuccin Frappe Flamingo: Catppuccin Frappe Flamingo
+      Catppuccin Frappe Pink: Catppuccin Frappe Pink
+      Everforest Light Blue: Everforest Lys Blå
+      Gruvbox Dark Orange: Gruvbox Mørk Orange
+      Gruvbox Light Purple: Gruvbox Lys Lilla
+      Everforest Dark Red: Everforest Mørk Rød
+      Everforest Dark Yellow: Everforest Mørk Gul
+      Everforest Dark Green: Everforest Mørk Grøn
+      Everforest Light Orange: Everforest Lys Orange
+      Everforest Light Yellow: Everforest Lys Gul
+      Everforest Light Green: Everforest Lys Grøn
+      Catppuccin Frappe Rosewater: Catppuccin Frappe Rosenvand
+      Everforest Light Aqua: Everforest Lys Aqua
+      Solarized Cyan: Solarized Cyan
+      Everforest Light Purple: Everforest Lys Lilla
+      Gruvbox Dark Aqua: Gruvbox Mørk Aqua
+      Gruvbox Light Orange: Gruvbox Lys Orange
+      Everforest Light Red: Everforest Lys Rød
+      Solarized Yellow: Solarized Gul
+      Solarized Orange: Solarized Orange
+      Catppuccin Frappe Green: Catppuccin Frappe Grøn
     Secondary Color Theme: 'Sekundær Farvetema'
         #* Main Color Theme
     UI Scale: Skalering af Brugerflade
@@ -318,12 +398,12 @@ Settings:
     Hide Side Bar Labels: Skjul Sidebarens Etiketter
     Hide FreeTube Header Logo: Skjul FreeTube Overskriftslogo
   Player Settings:
-    Player Settings: 'Afspilningsindstillinger'
-    Play Next Video: 'Afspil Næste Video'
-    Turn on Subtitles by Default: 'Slå Undertekster til som Standard'
-    Autoplay Videos: 'Autospil Videoer'
+    Player Settings: 'Afspiller'
+    Play Next Video: 'Auto-afspil anbefalede videoer'
+    Turn on Subtitles by Default: 'Aktivér undertekster som standard'
+    Autoplay Videos: 'Start videoer automatisk'
     Proxy Videos Through Invidious: 'Kør Videoer Gennem Invidious-Proxy'
-    Autoplay Playlists: 'Autospil Playlister'
+    Autoplay Playlists: 'Auto-afspil playlister'
     Enable Theatre Mode by Default: 'Aktivér Biograftilstand som Standard'
     Default Volume: 'Standard Lydstyrke'
     Default Playback Rate: 'Standard Afspilningshastighed'
@@ -358,7 +438,7 @@ Settings:
         3 tal. %s Video-sekund. %t Video-millisekund 3 tal. %i Video-ID.
       Ask Path: Spørg efter Mappe til at Gemme
       Folder Label: Mappe til Skærmbilleder
-    Next Video Interval: Næste Videointerval
+    Next Video Interval: Nedtællingstimer til auto-afspilning
     Max Video Playback Rate: Maks. Videoafspilningshastighed
     Display Play Button In Video Player: Vis Afspilningsknap i Videoafspiller
     Fast-Forward / Rewind Interval: Spol fremad / Spol tilbage Interval
@@ -366,9 +446,16 @@ Settings:
     Scroll Playback Rate Over Video Player: Scroll Afspilningshastighed i Videoafspiller
     Scroll Volume Over Video Player: Scroll Lydstyrke i Videoafspiller
     Skip by Scrolling Over Video Player: Spring Over ved at Scrolle Over Videoafspilleren
+    Default Viewing Mode:
+      Theater: Biograf
+      Default Viewing Mode: Standardvisningstilstand
+      Full Screen: Fuldskærm
+      Picture in Picture: Billede-i-billede
+      External Player: Ekstern afspiller ({externalPlayerName})
+    Enter Fullscreen on Display Rotate: Skift til fuldskærm ved skærmrotation
   Privacy Settings:
-    Privacy Settings: 'Privatlivsindstillinger'
-    Remember History: 'Husk Historik'
+    Privacy Settings: 'Privatliv'
+    Remember History: 'Husk visningshistorik'
     Save Watched Progress: 'Gem Set Fremskridt'
     Clear Search Cache: 'Ryd Søgecache'
     Are you sure you want to clear out your search cache?: 'Er du sikker på, at du
@@ -388,12 +475,19 @@ Settings:
     Save Watched Videos With Last Viewed Playlist: Gem Sete Videoer med Sidst Sete
       Playliste
     Remove All Playlists: Fjern Alle Playlister
+    Remember Search History: Husk søgehistorik
+    Are you sure you want to clear out your search history and cache?: Er du sikker
+      på, at du vil rydde din søgehistorik og cache?
+    Search history and cache have been cleared: Søgehistorik og cache blev ryddet
+    Clear Search History and Cache: Ryd søgehistorik og cache
   Subscription Settings:
-    Subscription Settings: 'Abonnementsindstillinger'
+    Subscription Settings: 'Abonnement'
     Hide Videos on Watch: 'Skjul Videoer på Se'
     Fetch Feeds from RSS: 'Hent Feeds fra RSS'
     Fetch Automatically: Hent Feed Automatisk
     Confirm Before Unsubscribing: Bekræft Før Afmelding
+    'Limit the number of videos displayed for each channel': Begræns antallet af videoer
+      vist for hver kanal
   Data Settings:
     Data Settings: 'Dataindstillinger'
     Select Export Type: 'Vælg Eksporttype'
@@ -462,7 +556,7 @@ Settings:
     Hide Channel Subscribers: Skjul Kanal-Abonnenter
     Hide Video Likes And Dislikes: Skjul Video-Likes og -Dislikes
     Hide Video Views: Skjul Videovisninger
-    Distraction Free Settings: Distraktionsfri Indstillinger
+    Distraction Free Settings: Distraktionsfri
     Hide Live Streams: Skjul Livestreams
     Hide Comments: Skjul Kommentarer
     Hide Sharing Actions: Skjul Delingshandlinger
@@ -480,6 +574,8 @@ Settings:
     Sections:
       General: Generelt
       Side Bar: Sidebjælke
+      Channel Page: Kanalside
+      Subscriptions Page: Abonnementsside
     Hide Channels Placeholder: Kanal-ID
     Hide Channels API Error: Fejl ved hentning af bruger med det angivne ID. Tjek
       venligst igen, om ID'et er korrekt.
@@ -522,10 +618,11 @@ Settings:
     Custom External Player Arguments: Brugerdefineret Ekstern Afspiller Argumenter
     External Player: Ekstern Afspiller
     Ignore Unsupported Action Warnings: Ignorér Advarsler om Ikke-understøttede Handlinger
-    External Player Settings: Indstillinger for Ekstern Afspiller
+    External Player Settings: Ekstern afspiller
     Players:
       None:
         Name: Ingen
+    Ignore Default Arguments: Ignorer standardargumenter
   Password Settings:
     Set Password: Indstil Adgangskode
     Password Settings: Adgangskode-indstillinger
@@ -913,6 +1010,7 @@ Default Invidious instance has been cleared: Standard Invidious-instans er bleve
 Are you sure you want to open this link?: Er du sikker på, at du vil åbne dette link?
 Search Bar:
   Clear Input: Ryd Input
+  Remove: Fjern
 Downloading failed: Der var et problem med at downloade "{videoTitle}"
 Unknown YouTube url type, cannot be opened in app: Ukendt YouTube URL-type, kan ikke
   åbnes i appen
@@ -941,5 +1039,13 @@ Search Listing:
   Label:
     Subtitles: Undertekster
     4K: 4K
+    3D: 3D
+    Closed Captions: Undertekster
+    8K: 8K
+    VR180: VR180
+    360 Video: 360°
 Feed:
   Refresh Feed: Opdater {subscriptionName}
+  Feed Last Updated: '{feedName}-feed opdateret sidst: {date}'
+Right-click or hold to see history: Højreklik eller hold nede for at se historik
+Search character limit: Søgningen overskrider tegngrænsen {searchCharacterLimit}

--- a/static/locales/en-GB.yaml
+++ b/static/locales/en-GB.yaml
@@ -399,6 +399,19 @@ Settings:
       Catppuccin Frappe Teal: Catppuccin Frappe Teal
       Catppuccin Frappe Green: Catppuccin Frappe Green
       Everforest Dark Red: Everforest Dark Red
+      Everforest Dark Yellow: Everforest Dark Yellow
+      Everforest Light Orange: Everforest Light Orange
+      Everforest Light Blue: Everforest Light Blue
+      Everforest Light Purple: Everforest Light Purple
+      Everforest Light Green: Everforest Light Green
+      Everforest Dark Aqua: Everforest Dark Aqua
+      Everforest Dark Blue: Everforest Dark Blue
+      Everforest Dark Purple: Everforest Dark Purple
+      Everforest Light Yellow: Everforest Light Yellow
+      Everforest Light Aqua: Everforest Light Aqua
+      Everforest Dark Green: Everforest Dark Green
+      Everforest Dark Orange: Everforest Dark Orange
+      Everforest Light Red: Everforest Light Red
     Secondary Color Theme: 'Secondary colour theme'
         #* Main Color Theme
     UI Scale: UI Scale
@@ -614,6 +627,7 @@ Settings:
       text
     Hide Channel Home: Hide Channel "Home" Tab
     Show Added Items: Show Added Items
+    Hide Channel Courses: Hide Channel "Courses" Tab
   The app needs to restart for changes to take effect. Restart and apply change?: The
     app needs to restart for changes to take effect. Do you want to restart and apply
     the changes?
@@ -829,6 +843,10 @@ Channel:
   Home:
     Home: Home
     View Playlist: View Playlist
+  Courses:
+    Courses: Courses
+    This channel does not currently have any courses: This channel does not currently
+      have any courses
 Video:
   Mark As Watched: 'Mark As Watched'
   Remove From History: 'Remove From History'

--- a/static/locales/fa.yaml
+++ b/static/locales/fa.yaml
@@ -309,6 +309,12 @@ Settings:
       Gruvbox Light: جعبه تیره روشن
       Nordic: شمال اروپا
       Catppuccin Frappe: تم رنگ کت پوچین فراپه
+      Everforest Light Medium: جنگل ابدی روشن متوسط
+      Everforest Light Hard: جنگل ابدی روشن سخت
+      Everforest Dark Hard: جنگل ابدی تاریک سخت
+      Everforest Dark Medium: جنگل ابدی تاریک متوسط
+      Everforest Dark Low: جنگل ابدی تاریک کم
+      Everforest Light Low: جنگل ابدی روشن کم
     Main Color Theme:
       Main Color Theme: 'رنگ تم اصلی'
       Red: 'قرمز'
@@ -380,6 +386,20 @@ Settings:
       Catppuccin Frappe Sapphire: کتپوچین فراپه یاقوت کبود
       Catppuccin Frappe Blue: کتپوچین فراپه آبی
       Catppuccin Frappe Red: کتپوچین فراپه قرمز
+      Everforest Light Green: جنگل ابدی سبز روشن
+      Everforest Light Aqua: جنگل ابدی آسمانی روشن
+      Everforest Light Blue: جنگل ابدی آبی روشن
+      Everforest Light Purple: جنگل ابدی بنفش روشن
+      Everforest Dark Red: جنگل ابدی قرمز تیره
+      Everforest Dark Orange: جنگل ابدی نارنجی تیره
+      Everforest Dark Yellow: جنگل ابدی زرد تیره
+      Everforest Dark Green: جنگل ابدی سبز تیره
+      Everforest Dark Aqua: جنگل ابدی آسمانی تیره
+      Everforest Dark Blue: جنگل ابدی آبی تیره
+      Everforest Dark Purple: جنگل ابدی ینفش تیره
+      Everforest Light Red: جنگل ابدی قرمز روشن
+      Everforest Light Orange: جنگل ابدی نارنجی روشن
+      Everforest Light Yellow: جنگل ابدی زرد روشن
     Secondary Color Theme: 'رنگ دوم تم'
         #* Main Color Theme
     Hide Side Bar Labels: مخفی کردن عنوان های ستون فرعی
@@ -388,9 +408,9 @@ Settings:
     Player Settings: 'پخش کننده'
     Play Next Video: 'پخش اتوماتیک ویدیو پیشنهادی'
     Turn on Subtitles by Default: 'فعال کردن زیرنویس به عنوان پیشفرض'
-    Autoplay Videos: 'پخش خودکار ویدیو ها'
+    Autoplay Videos: 'شروع خودکار ویدیوها'
     Proxy Videos Through Invidious: 'پروکسی ویدیو ها از طریق Invidious'
-    Autoplay Playlists: 'پخش خودکار فهرست  پخش'
+    Autoplay Playlists: 'پخش خودکار فهرست پخش'
     Enable Theatre Mode by Default: 'فعال کردن حالت تئاتر به عنوان پیشفرض'
     Scroll Volume Over Video Player: 'کنترل صدا با حرکت اسکرول موس روی پخش کننده ویدیو'
     Display Play Button In Video Player: 'نمایش دکمه پخش داخل پخش کننده ویدیو'
@@ -428,9 +448,8 @@ Settings:
       File Name Label: الگوی نام فایل
       Quality Label: کیفیت اسکرین شات
       File Name Tooltip: می توانید از متغیرهای زیر استفاده کنید. %Y سال 4 رقم. رقم
-        %M ماه 2. %D رقم روز دوم. %H ساعت 2 رقمی. %N دقیقه 2 رقم. %S 2 رقم دوم. %T
-        میلی ثانیه 3 رقمی. %s ویدیو دوم. %t ویدیو میلی ثانیه 3 رقمی. %i شناسه ویدیو.
-        همچنین می توانید از '\\' یا '/' برای ایجاد زیرپوشه ها استفاده کنید.
+        %M ماه 2. %D رقم روز 2. %H ساعت 2 رقمی. %N دقیقه 2 رقم. %S 2 رقم دوم. %T میلی
+        ثانیه 3 رقمی. %s ویدیو دوم. %t ویدیو میلی ثانیه 3 رقمی. %i شناسه ویدیو.
       Enable: اسکرین شات فعال باشد
       Ask Path: پرسش برای محل ذخیره
       Folder Label: پوشه اسکرین شات
@@ -455,7 +474,7 @@ Settings:
     Ignore Default Arguments: نادیده گرفتن برهان های پیش فرض
   Privacy Settings:
     Privacy Settings: 'امنیتی'
-    Remember History: 'حفظ تاریخچه'
+    Remember History: 'حفظ تاریخچه تماشا'
     Save Watched Progress: 'ذخیره ویدیو های دیده شده'
     Clear Search Cache: 'پاک کردن کش جستجو'
     Are you sure you want to clear out your search cache?: 'آیا مطمئن هستید که میخواهید
@@ -541,6 +560,7 @@ Settings:
       و پردازش نشدند. در حالی که آن شناسه ها در حال به روز رسانی هستند، ویژگی مسدود
       می شود
     Show Added Items: نمایش موارد اضافه شده
+    Hide Channel Courses: پنهان کردن زبانه "دوره‌ها" کانال
   Data Settings:
     Data Settings: 'داده ها'
     Select Export Type: 'انتخاب روش پشتیبان گیری'
@@ -729,6 +749,10 @@ Channel:
   Home:
     View Playlist: نمایش لیست‌پخش
     Home: خانه
+  Courses:
+    Courses: دوره ها
+    This channel does not currently have any courses: این کانال در حال حاضر هیچ دوره‌ای
+      ندارد
 Video:
   External Player:
     video: ویدیو
@@ -1111,7 +1135,7 @@ Profile:
   Profile Name: نام نمایه
   Open Profile Dropdown: بازکردن نمایه کشویی
   Close Profile Dropdown: بستن نمایه کشویی
-Screenshot Success: اسکرین شات به عنوان «{filePath}» ذخیره شد
+Screenshot Success: عکس‌صفحه ذخیره شد
 Ok: تایید
 Downloading has completed: دانلود '{videoTitle}' به پایان رسید
 Loop is now enabled: حلقه اکنون فعال است

--- a/static/locales/fr-FR.yaml
+++ b/static/locales/fr-FR.yaml
@@ -635,7 +635,7 @@ Settings:
       phrase
     Hide Channel Home: Masquer l'onglet « Accueil » de la chaîne
     Show Added Items: Afficher les éléments ajoutés
-    Hide Channel Courses: Masquer l'onglet de la chaîne "Cours"
+    Hide Channel Courses: Masquer l'onglet de la chaîne « Cours »
   The app needs to restart for changes to take effect. Restart and apply change?: L'application
     doit être redémarrée pour que les changements prennent effet. Redémarrer et appliquer
     les changements ?

--- a/static/locales/is.yaml
+++ b/static/locales/is.yaml
@@ -573,6 +573,7 @@ Settings:
     Hide Videos and Playlists Containing Text Placeholder: Orð, orðhluti eða setning
     Hide Channel Home: Fela "Heim"-flipa rása
     Show Added Items: Sýna atriði sem bætt hefur verið við
+    Hide Channel Courses: Fela flipann með rásinni "Kennsluefni"
   Data Settings:
     Data Settings: 'Gögn'
     Select Export Type: 'Veldu tegund útflutnings'
@@ -846,6 +847,10 @@ Channel:
   Home:
     Home: Heim
     View Playlist: Skoða spilunarlista
+  Courses:
+    Courses: Kennsluefni
+    This channel does not currently have any courses: Þessi rás er ekki með neitt
+      kennsluefni
 Video:
   Mark As Watched: 'Merkja sem búið að horfa á'
   Remove From History: 'Fjarlægja úr áhorfsferli'

--- a/yarn.lock
+++ b/yarn.lock
@@ -3691,10 +3691,10 @@ electron-to-chromium@^1.5.73:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.96.tgz#afa3bf1608c897a7c7e33f22d4be1596dd5a4f3e"
   integrity sha512-8AJUW6dh75Fm/ny8+kZKJzI1pgoE8bKLZlzDU2W1ENd+DXKJrx7I7l9hb8UWR4ojlnb5OlixMt00QWiYJoVw1w==
 
-electron@^35.0.1:
-  version "35.0.1"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-35.0.1.tgz#8596e3936c4b5787e0cf52739bf6842925cfcdc1"
-  integrity sha512-iQonj6lnPhqfqha2KXx6LzV1dnu6UPTCWK+b7f9Zvg828umGemi22DKbcJ3/q+Opn7iUVTWyqp9z1JQqkIi6OA==
+electron@^35.0.2:
+  version "35.0.2"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-35.0.2.tgz#06e54526056a4d9eaa0132a6940d5cfa10d27c16"
+  integrity sha512-jo8S4GfBpVIBDGitUrv+Vo/I/ZEEs6IvWprG2KJlxayYIKpufulbQaxDt78cC/79FwFo8MA0JOIwx/b9r5NRag==
   dependencies:
     "@electron/get" "^2.0.0"
     "@types/node" "^22.7.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4146,10 +4146,10 @@ eslint-plugin-import-x@^4.5.0:
     stable-hash "^0.0.4"
     tslib "^2.6.3"
 
-eslint-plugin-jsdoc@^50.6.3:
-  version "50.6.3"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-50.6.3.tgz#668dc4d32e823c84ede7310cffbf70c9d370d291"
-  integrity sha512-NxbJyt1M5zffPcYZ8Nb53/8nnbIScmiLAMdoe0/FAszwb7lcSiX3iYBTsuF7RV84dZZJC8r3NghomrUXsmWvxQ==
+eslint-plugin-jsdoc@^50.6.6:
+  version "50.6.6"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-50.6.6.tgz#131fca9f5afe891a454afc49976c2693454ee6ec"
+  integrity sha512-4jLo9NZqHfyNtiBxAU293eX1xi6oUIBcAxJJL/hHeeNhh26l4l/Apmu0x9SarvSQ/gWNOrnFci4DSPupN4//WA==
   dependencies:
     "@es-joy/jsdoccomment" "~0.49.0"
     are-docs-informative "^0.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1273,10 +1273,10 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@keyv/serialize@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@keyv/serialize/-/serialize-1.0.2.tgz#72507c4be94d8914434a4aa80661f8ac6131967f"
-  integrity sha512-+E/LyaAeuABniD/RvUezWVXKpeuvwLEA9//nE9952zBaOdBd2mQ3pPoM8cUe2X6IcMByfuSLzmYqnYshG60+HQ==
+"@keyv/serialize@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@keyv/serialize/-/serialize-1.0.3.tgz#e0fe3710e2a379cb0490cd41e5a5ffa2bab58bf6"
+  integrity sha512-qnEovoOp5Np2JDGonIDL6Ayihw0RhnRh6vxPuHo4RDn1UOzwEo4AeIfpL6UGIrsceWrCMiVPgwRjbHu4vYFc3g==
   dependencies:
     buffer "^6.0.3"
 
@@ -2734,13 +2734,13 @@ cacheable-request@^7.0.2:
     normalize-url "^6.0.1"
     responselike "^2.0.0"
 
-cacheable@^1.8.8:
-  version "1.8.8"
-  resolved "https://registry.yarnpkg.com/cacheable/-/cacheable-1.8.8.tgz#d105f6de41811e42acfa1327718f955794f879a6"
-  integrity sha512-OE1/jlarWxROUIpd0qGBSKFLkNsotY8pt4GeiVErUYh/NUeTNrT+SBksUgllQv4m6a0W/VZsLuiHb88maavqEw==
+cacheable@^1.8.9:
+  version "1.8.9"
+  resolved "https://registry.yarnpkg.com/cacheable/-/cacheable-1.8.9.tgz#f5498999567ae1015761d805bd8bbecd8393fbd4"
+  integrity sha512-FicwAUyWnrtnd4QqYAoRlNs44/a1jTL7XDKqm5gJ90wz1DQPlC7U2Rd1Tydpv+E7WAr4sQHuw8Q8M3nZMAyecQ==
   dependencies:
-    hookified "^1.7.0"
-    keyv "^5.2.3"
+    hookified "^1.7.1"
+    keyv "^5.3.1"
 
 call-bind@^1.0.0, call-bind@^1.0.2:
   version "1.0.2"
@@ -4543,12 +4543,12 @@ fdir@^6.4.3:
   resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.4.3.tgz#011cdacf837eca9b811c89dbb902df714273db72"
   integrity sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==
 
-file-entry-cache@^10.0.6:
-  version "10.0.6"
-  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-10.0.6.tgz#1fc49c38231b56e792c65222c0aa519d40b5db55"
-  integrity sha512-0wvv16mVo9nN0Md3k7DMjgAPKG/TY4F/gYMBVb/wMThFRJvzrpaqBFqF6km9wf8QfYTN+mNg5aeaBLfy8k35uA==
+file-entry-cache@^10.0.7:
+  version "10.0.7"
+  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-10.0.7.tgz#e0ac34d4b8c44bea8a0a27ceb4dae982f2d32749"
+  integrity sha512-txsf5fu3anp2ff3+gOJJzRImtrtm/oa9tYLN0iTuINZ++EyVR/nRrg2fKYwvG/pXDofcrvvb0scEbX3NyW/COw==
   dependencies:
-    flat-cache "^6.1.6"
+    flat-cache "^6.1.7"
 
 file-entry-cache@^8.0.0:
   version "8.0.0"
@@ -4613,14 +4613,14 @@ flat-cache@^4.0.0:
     flatted "^3.2.9"
     keyv "^4.5.4"
 
-flat-cache@^6.1.6:
-  version "6.1.6"
-  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-6.1.6.tgz#62a94ba475297ec742d6c3a2be6516a96d311c9e"
-  integrity sha512-F+CKgSwp0pzLx67u+Zy1aCueVWFAHWbXepvXlZ+bWVTaASbm5SyCnSJ80Fp1ePEmS57wU+Bf6cx6525qtMZ4lQ==
+flat-cache@^6.1.7:
+  version "6.1.7"
+  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-6.1.7.tgz#c04b08316739ad7ef997e1b9ea363443fc2fcb38"
+  integrity sha512-qwZ4xf1v1m7Rc9XiORly31YaChvKt6oNVHuqqZcoED/7O+ToyNVGobKsIAopY9ODcWpEDKEBAbrSOCBHtNQvew==
   dependencies:
-    cacheable "^1.8.8"
-    flatted "^3.3.2"
-    hookified "^1.7.0"
+    cacheable "^1.8.9"
+    flatted "^3.3.3"
+    hookified "^1.7.1"
 
 flat@^5.0.2:
   version "5.0.2"
@@ -4632,10 +4632,10 @@ flatted@^3.2.9:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.3.1.tgz#21db470729a6734d4997002f439cb308987f567a"
   integrity sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==
 
-flatted@^3.3.2:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.3.2.tgz#adba1448a9841bec72b42c532ea23dbbedef1a27"
-  integrity sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==
+flatted@^3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.3.3.tgz#67c8fad95454a7c7abebf74bb78ee74a44023358"
+  integrity sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==
 
 follow-redirects@^1.0.0:
   version "1.15.6"
@@ -5146,10 +5146,10 @@ he@^1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
-hookified@^1.7.0:
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/hookified/-/hookified-1.7.1.tgz#b08228173e06e9e8767bae1dffb216b8c6171b41"
-  integrity sha512-OXcdHsXeOiD7OJ5zvWj8Oy/6RCdLwntAX+wUrfemNcMGn6sux4xbEHi2QXwqePYhjQ/yvxxq2MvCRirdlHscBw==
+hookified@^1.7.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/hookified/-/hookified-1.8.1.tgz#74a8c97d36e5f8004d230ee2156a607cc84c358c"
+  integrity sha512-GrO2l93P8xCWBSTBX9l2BxI78VU/MAAYag+pG8curS3aBGy0++ZlxrQ7PdUOUVMbn5BwkGb6+eRrnf43ipnFEA==
 
 hosted-git-info@^4.1.0:
   version "4.1.0"
@@ -6081,12 +6081,12 @@ keyv@^4.5.4:
   dependencies:
     json-buffer "3.0.1"
 
-keyv@^5.2.3:
-  version "5.2.3"
-  resolved "https://registry.yarnpkg.com/keyv/-/keyv-5.2.3.tgz#32db1a4aa8d05e2b8ab82688a57ddc5d2184a25c"
-  integrity sha512-AGKecUfzrowabUv0bH1RIR5Vf7w+l4S3xtQAypKaUpTdIR1EbrAcTxHCrpo9Q+IWeUlFE2palRtgIQcgm+PQJw==
+keyv@^5.3.1:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/keyv/-/keyv-5.3.2.tgz#32edd461b51d44d42926eb72946236d79c71ae78"
+  integrity sha512-Lji2XRxqqa5Wg+CHLVfFKBImfJZ4pCSccu9eVWK6w4c2SDFLd8JAn1zqTuSFnsxb7ope6rMsnIHfp+eBbRBRZQ==
   dependencies:
-    "@keyv/serialize" "^1.0.2"
+    "@keyv/serialize" "^1.0.3"
 
 kind-of@^6.0.2:
   version "6.0.3"
@@ -8688,10 +8688,10 @@ stylelint-use-logical-spec@^5.0.1:
   resolved "https://registry.yarnpkg.com/stylelint-use-logical-spec/-/stylelint-use-logical-spec-5.0.1.tgz#d5aa254d615d373f18214297c0b49a03a6ca5980"
   integrity sha512-UfLB4LW6iG4r3cXxjxkiHQrFyhWFqt8FpNNngD+TyvgMWSokk5TYwTvBHS3atUvZhOogllTOe/PUrGE+4z84AA==
 
-stylelint@^16.15.0, stylelint@^16.8.2:
-  version "16.15.0"
-  resolved "https://registry.yarnpkg.com/stylelint/-/stylelint-16.15.0.tgz#a561cd50ad468cc4898f5c57cc1f223287fdea59"
-  integrity sha512-OK6Rs7EPdcdmjqiDycadZY4fw3f5/TC1X6/tGjnF3OosbwCeNs7nG+79MCAtjEg7ckwqTJTsku08e0Rmaz5nUw==
+stylelint@^16.16.0, stylelint@^16.8.2:
+  version "16.16.0"
+  resolved "https://registry.yarnpkg.com/stylelint/-/stylelint-16.16.0.tgz#ebecf27becd277aaf752e75de324023a1e13e486"
+  integrity sha512-40X5UOb/0CEFnZVEHyN260HlSSUxPES+arrUphOumGWgXERHfwCD0kNBVILgQSij8iliYVwlc0V7M5bcLP9vPg==
   dependencies:
     "@csstools/css-parser-algorithms" "^3.0.4"
     "@csstools/css-tokenizer" "^3.0.3"
@@ -8706,7 +8706,7 @@ stylelint@^16.15.0, stylelint@^16.8.2:
     debug "^4.3.7"
     fast-glob "^3.3.3"
     fastest-levenshtein "^1.0.16"
-    file-entry-cache "^10.0.6"
+    file-entry-cache "^10.0.7"
     global-modules "^2.0.0"
     globby "^11.1.0"
     globjoin "^0.1.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -34,34 +34,34 @@
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.26.8.tgz#821c1d35641c355284d4a870b8a4a7b0c141e367"
   integrity sha512-oH5UPLMWR3L2wEFLnFJ1TZXqHufiTKAiLfqw5zkhS4dKXLJ10yVztfil/twG8EDTA4F/tvVNw9nOl4ZMslB8rQ==
 
-"@babel/core@^7.26.9":
-  version "7.26.9"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.26.9.tgz#71838542a4b1e49dfed353d7acbc6eb89f4a76f2"
-  integrity sha512-lWBYIrF7qK5+GjY5Uy+/hEgp8OJWOD/rpy74GplYRhEauvbHDeFB8t5hPOZxCZ0Oxf4Cc36tK51/l3ymJysrKw==
+"@babel/core@^7.26.10":
+  version "7.26.10"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.26.10.tgz#5c876f83c8c4dcb233ee4b670c0606f2ac3000f9"
+  integrity sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==
   dependencies:
     "@ampproject/remapping" "^2.2.0"
     "@babel/code-frame" "^7.26.2"
-    "@babel/generator" "^7.26.9"
+    "@babel/generator" "^7.26.10"
     "@babel/helper-compilation-targets" "^7.26.5"
     "@babel/helper-module-transforms" "^7.26.0"
-    "@babel/helpers" "^7.26.9"
-    "@babel/parser" "^7.26.9"
+    "@babel/helpers" "^7.26.10"
+    "@babel/parser" "^7.26.10"
     "@babel/template" "^7.26.9"
-    "@babel/traverse" "^7.26.9"
-    "@babel/types" "^7.26.9"
+    "@babel/traverse" "^7.26.10"
+    "@babel/types" "^7.26.10"
     convert-source-map "^2.0.0"
     debug "^4.1.0"
     gensync "^1.0.0-beta.2"
     json5 "^2.2.3"
     semver "^6.3.1"
 
-"@babel/generator@^7.26.9":
-  version "7.26.9"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.26.9.tgz#75a9482ad3d0cc7188a537aa4910bc59db67cbca"
-  integrity sha512-kEWdzjOAUMW4hAyrzJ0ZaTOu9OmpyDIQicIh0zg0EEcEkYXZb2TjtBhnHi2ViX7PKwZqF4xwqfAm299/QMP3lg==
+"@babel/generator@^7.26.10":
+  version "7.26.10"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.26.10.tgz#a60d9de49caca16744e6340c3658dfef6138c3f7"
+  integrity sha512-rRHT8siFIXQrAYOYqZQVsAr8vJ+cBNqcVAY6m5V8/4QqzaPl+zDBe6cLEPRDuNOUf3ww8RfJVlOyQMoSI+5Ang==
   dependencies:
-    "@babel/parser" "^7.26.9"
-    "@babel/types" "^7.26.9"
+    "@babel/parser" "^7.26.10"
+    "@babel/types" "^7.26.10"
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.25"
     jsesc "^3.0.2"
@@ -230,20 +230,20 @@
     "@babel/traverse" "^7.25.9"
     "@babel/types" "^7.25.9"
 
-"@babel/helpers@^7.26.9":
-  version "7.26.9"
-  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.26.9.tgz#28f3fb45252fc88ef2dc547c8a911c255fc9fef6"
-  integrity sha512-Mz/4+y8udxBKdmzt/UjPACs4G3j5SshJJEFFKxlCGPydG4JAHXxjWjAwjd09tf6oINvl1VfMJo+nB7H2YKQ0dA==
+"@babel/helpers@^7.26.10":
+  version "7.26.10"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.26.10.tgz#6baea3cd62ec2d0c1068778d63cb1314f6637384"
+  integrity sha512-UPYc3SauzZ3JGgj87GgZ89JVdC5dj0AoetR5Bw6wj4niittNyFh6+eOGonYvJ1ao6B8lEa3Q3klS7ADZ53bc5g==
   dependencies:
     "@babel/template" "^7.26.9"
-    "@babel/types" "^7.26.9"
+    "@babel/types" "^7.26.10"
 
-"@babel/parser@^7.23.5", "@babel/parser@^7.26.9":
-  version "7.26.9"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.26.9.tgz#d9e78bee6dc80f9efd8f2349dcfbbcdace280fd5"
-  integrity sha512-81NWa1njQblgZbQHxWHpxxCzNsa3ZwvFqpUg7P+NNUU6f3UU2jBEg4OlF/J6rl8+PQGh1q6/zWScd001YwcA5A==
+"@babel/parser@^7.23.5", "@babel/parser@^7.26.10", "@babel/parser@^7.26.9":
+  version "7.26.10"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.26.10.tgz#e9bdb82f14b97df6569b0b038edd436839c57749"
+  integrity sha512-6aQR2zGE/QFi8JpDLjUZEPYOs7+mhKXm86VaKFiLP35JQwQb6bwUE+XbvkH0EptsYhbNBSUGaUBLKqxH1xSgsA==
   dependencies:
-    "@babel/types" "^7.26.9"
+    "@babel/types" "^7.26.10"
 
 "@babel/plugin-bugfix-firefox-class-in-computed-class-key@^7.25.9":
   version "7.25.9"
@@ -805,23 +805,23 @@
     "@babel/parser" "^7.26.9"
     "@babel/types" "^7.26.9"
 
-"@babel/traverse@^7.25.9", "@babel/traverse@^7.26.8", "@babel/traverse@^7.26.9":
-  version "7.26.9"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.26.9.tgz#4398f2394ba66d05d988b2ad13c219a2c857461a"
-  integrity sha512-ZYW7L+pL8ahU5fXmNbPF+iZFHCv5scFak7MZ9bwaRPLUhHh7QQEMjZUg0HevihoqCM5iSYHN61EyCoZvqC+bxg==
+"@babel/traverse@^7.25.9", "@babel/traverse@^7.26.10", "@babel/traverse@^7.26.8":
+  version "7.26.10"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.26.10.tgz#43cca33d76005dbaa93024fae536cc1946a4c380"
+  integrity sha512-k8NuDrxr0WrPH5Aupqb2LCVURP/S0vBEn5mK6iH+GIYob66U5EtoZvcdudR2jQ4cmTwhEwW1DLB+Yyas9zjF6A==
   dependencies:
     "@babel/code-frame" "^7.26.2"
-    "@babel/generator" "^7.26.9"
-    "@babel/parser" "^7.26.9"
+    "@babel/generator" "^7.26.10"
+    "@babel/parser" "^7.26.10"
     "@babel/template" "^7.26.9"
-    "@babel/types" "^7.26.9"
+    "@babel/types" "^7.26.10"
     debug "^4.3.1"
     globals "^11.1.0"
 
-"@babel/types@^7.18.6", "@babel/types@^7.25.9", "@babel/types@^7.26.9", "@babel/types@^7.4.4":
-  version "7.26.9"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.26.9.tgz#08b43dec79ee8e682c2ac631c010bdcac54a21ce"
-  integrity sha512-Y3IR1cRnOxOCDvMmNiym7XpXQ93iGDDPHx+Zj+NM+rg0fBaShfQLkg+hKPaZCEvg5N/LeCo4+Rj/i3FuJsIQaw==
+"@babel/types@^7.18.6", "@babel/types@^7.25.9", "@babel/types@^7.26.10", "@babel/types@^7.26.9", "@babel/types@^7.4.4":
+  version "7.26.10"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.26.10.tgz#396382f6335bd4feb65741eacfc808218f859259"
+  integrity sha512-emqcG3vHrpxUKTrxcblR36dcrcoRDvKmnL/dCL6ZsHaShW80qxCAcNhzQZrpeM765VzEos+xOi4s+r4IXzTwdQ==
   dependencies:
     "@babel/helper-string-parser" "^7.25.9"
     "@babel/helper-validator-identifier" "^7.25.9"


### PR DESCRIPTION
Pull Request Type
<!-- Please select what type of pull request this is: [x] --> 
•	Bugfix X
•	Feature Implementation
•	Documentation
•	Other
Related Issue
Closes #6597
Description
•	Improved contrast for uploader comment highlights in the Catppuccin Mocha theme.
•	Updated card-bg-color and secondary-card-bg-color values to ensure readability.
•	Ensured consistency with other themes (Light, Dark).
Screenshots <!-- If appropriate -->
 

Testing 
![vv](https://github.com/user-attachments/assets/9d381f1f-e78d-4f50-9072-2ce9e1fbc13d)

•	Manually tested theme switching between Catppuccin Mocha, Light, and Dark.
•	Verified contrast ratio meets accessibility guidelines (4.5:1).
•	Checked that the changes do not break other elements.
Desktop
•	OS: [Windows ]
•	OS Version: [Windows 10 pro]
•	FreeTube Version: [e.g., @0.23.2]

